### PR TITLE
Convenient no-args version of mock fn to create a simple spy

### DIFF
--- a/src/picomock/core.clj
+++ b/src/picomock/core.clj
@@ -78,11 +78,13 @@
     v))
 
 (defn mock
-  [f-or-fs]
-  (->Picomock
-   (create-call-state* (if (sequential? f-or-fs)
-                         f-or-fs
-                         [f-or-fs]))))
+  ([]
+   (mock (constantly nil)))
+  ([f-or-fs]
+   (->Picomock
+    (create-call-state* (if (sequential? f-or-fs)
+                          f-or-fs
+                          [f-or-fs])))))
 
 (defn mockval
   [retval]

--- a/test/picomock/unit/core.clj
+++ b/test/picomock/unit/core.clj
@@ -2,6 +2,20 @@
   (:require [picomock.core :refer :all]
             [clojure.test :refer :all]))
 
+;; example 0: a mock that captures calls and always returns nil to callers
+
+(deftest mock-with-no-fn-works-as-spy
+  (let [mymock (mock)]
+    (testing "the mock returns expected result"
+      (is (nil? (mymock 2 3))))
+    (testing "the mock has recorded the right number of calls"
+      (is (= 1 (mock-calls mymock))
+          "My mock wasn't called right number of times"))
+    (testing "the mock captured the right arguments"
+      (is (= '(2 3)
+             (first (mock-args mymock)))
+          "First call to my mock had wrong args"))))
+
 ;; example 1: passing a mock to a function that takes a function argument
 
 (defn example-function


### PR DESCRIPTION
I find that I regularly want the spying features of a mock, but I don't need to mock to return any value. This is usually for a side-effecting function that I want to make sure is called.

I'm often doing:

```clj
(mock (constantly nil))
```

so this commit adds a no-args version of `mock` that does this.